### PR TITLE
remove async from scoring fixes #4

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@
  * Dependencies
  */
 var _       = require('lodash'),
-    async   = require('async'),
     afinn   = require('../build/AFINN.json');
 
 /**
@@ -59,24 +58,24 @@ module.exports = function (phrase, inject, callback) {
         negative    = [];
 
     // Iterate over tokens
-    async.forEach(tokens, function (obj, callback) {
+    _.forEach(tokens, function (obj, callback) {
         var item = afinn[obj];
-        if (typeof item === 'undefined') return callback();
+        if (typeof item === 'undefined') return;
 
         words.push(obj);
         if (item > 0) positive.push(obj);
         if (item < 0) negative.push(obj);
 
         score += item;
-        callback();
-    }, function (err) {
-        callback(err, {
-            score:          score,
-            comparative:    score / tokens.length,
-            tokens:         tokens,
-            words:          words,
-            positive:       positive,
-            negative:       negative
-        });
     });
+
+    callback(null, {
+        score:          score,
+        comparative:    score / tokens.length,
+        tokens:         tokens,
+        words:          words,
+        positive:       positive,
+        negative:       negative
+    });
+
 };


### PR DESCRIPTION
fixes #4

This increases performance somewhere in the 90-100% range based on my running of the benchmarks.

Updating lodash may increase that further, but this change just removes the async lib from scoring.
