### PR TITLE
Speed up of token iteration loop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,8 +54,9 @@ module.exports = function (phrase, inject, callback) {
         negative    = [];
 
     // Iterate over tokens
-    for (var i = 0; i < tokens.length; i++) {
-        var obj = tokens[i];
+    var len = tokens.length;
+    while (len--) { 
+        var obj = tokens[len];
         var item = afinn[obj];
         if (typeof item === 'undefined') continue;
 


### PR DESCRIPTION
I know it is a micro optimization but from local testing it appears to speed up the execution by approximately 30,000 ops/sec see below benchmarks I ran locally:

for loop
sentiment (Latest) x 502,382 ops/sec ±4.20% (88 runs sampled)
Sentimental (1.0.1) x 213,516 ops/sec ±1.05% (96 runs sampled)

sentiment (Latest) x 506,713 ops/sec ±0.83% (97 runs sampled)
Sentimental (1.0.1) x 223,512 ops/sec ±0.93% (98 runs sampled)

sentiment (Latest) x 520,691 ops/sec ±0.76% (95 runs sampled)
Sentimental (1.0.1) x 221,518 ops/sec ±1.00% (95 runs sampled)

sentiment (Latest) x 547,038 ops/sec ±0.94% (96 runs sampled)
Sentimental (1.0.1) x 226,558 ops/sec ±0.87% (96 runs sampled)

sentiment (Latest) x 532,363 ops/sec ±1.10% (96 runs sampled)
Sentimental (1.0.1) x 223,907 ops/sec ±0.98% (96 runs sampled)

sentiment (Latest) x 525,713 ops/sec ±1.15% (94 runs sampled)
Sentimental (1.0.1) x 213,533 ops/sec ±0.99% (96 runs sampled) 

Average:  522, 483

while loop
sentiment (Latest) x 571,028 ops/sec ±1.29% (91 runs sampled)
Sentimental (1.0.1) x 37,201 ops/sec ±1.39% (91 runs sampled)

sentiment (Latest) x 560,211 ops/sec ±0.91% (97 runs sampled)
Sentimental (1.0.1) x 224,161 ops/sec ±1.13% (97 runs sampled)

sentiment (Latest) x 576,046 ops/sec ±0.82% (95 runs sampled)
Sentimental (1.0.1) x 219,440 ops/sec ±1.47% (97 runs sampled)

sentiment (Latest) x 550,552 ops/sec ±1.07% (94 runs sampled)
Sentimental (1.0.1) x 218,546 ops/sec ±1.02% (94 runs sampled)

sentiment (Latest) x 538,910 ops/sec ±1.38% (95 runs sampled)
Sentimental (1.0.1) x 222,141 ops/sec ±0.92% (99 runs sampled)

sentiment (Latest) x 522,955 ops/sec ±0.93% (98 runs sampled)
Sentimental (1.0.1) x 218,881 ops/sec ±1.05% (93 runs sampled)

Average 553, 82

Average speed up of 30,800 ops/sec
