### PR TITLE
Remove lodash.assign

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,6 @@
 /**
  * Dependencies
  */
-var assign = require('lodash.assign');
-
 var afinn = require('../build/AFINN.json');
 var tokenize = require('./tokenize');
 
@@ -30,7 +28,7 @@ module.exports = function (phrase, inject, callback) {
 
     // Merge
     if (inject !== null) {
-        afinn = assign(afinn, inject);
+        afinn = Object.assign(afinn, inject);
     }
 
     // Storage objects


### PR DESCRIPTION
Because this module is [Node 4 and above](https://github.com/thisandagain/sentiment/blob/develop/package.json#L31), we can remove the `lodash.assign` module and replace it with `Object.assign`.

If this presents compatibility concerns (old versions of Node, etc), feel free to ignore this pull request.