### PR TITLE
Add 'isn't' to negators.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,9 @@ var negators = {
     'not': 1,
     'non': 1,
     'wont': 1,
-    'won\'t': 1
+    'won\'t': 1,
+    'isnt': 1,
+    'isn\'t': 1
 };
 
 /**


### PR DESCRIPTION
'Isn't' wasn't included within the negators, but came up often in texts I [and presume others] were checking against, leading to inconsistencies.