### PR TITLE
Fix for replacing punctuation in tokenize.js

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -9,6 +9,8 @@ module.exports = function(input) {
     return input
         .toLowerCase()
         .replace(/\n/g, ' ')
-        .replace(/[.,\/#!$%\^&\*;:{}=_`\"~()]/g, '')
+        .replace(/[.,\/#!$%\^&\*;:{}=_`\"~()]/g, ' ')
+        .replace(/\s\s+/g, ' ')
+        .trim()
         .split(' ');
 };

--- a/test/integration/sync_corpus.js
+++ b/test/integration/sync_corpus.js
@@ -8,8 +8,8 @@ var result = sentiment.analyze(dataset);
 
 test('synchronous corpus', function (t) {
     t.type(result, 'object');
-    t.equal(result.score, -3);
-    t.equal(result.tokens.length, 1416);
-    t.equal(result.words.length, 73);
+    t.equal(result.score, -4);
+    t.equal(result.tokens.length, 1426);
+    t.equal(result.words.length, 74);
     t.end();
 });

--- a/test/unit/tokenize.js
+++ b/test/unit/tokenize.js
@@ -28,6 +28,14 @@ test('english', function (t) {
         tokenize('That\'ll cause problems for the farmer\'s pigs'),
         ['that\'ll', 'cause', 'problems', 'for', 'the', 'farmer\'s', 'pigs']
     );
+    t.deepEqual(
+        tokenize(' If you are    Razr owner...you must have this!  '),
+        ['if', 'you', 'are', 'razr', 'owner', 'you', 'must', 'have', 'this']
+    );
+    t.deepEqual(
+        tokenize('Tied to charger for conversations lasting more than 45 minutes.MAJOR PROBLEMS!!'),
+        ['tied', 'to', 'charger', 'for', 'conversations', 'lasting', 'more', 'than', '45', 'minutes', 'major', 'problems']
+    );
     t.end();
 });
 

--- a/test/unit/tokenize.js
+++ b/test/unit/tokenize.js
@@ -33,7 +33,9 @@ test('english', function (t) {
         ['if', 'you', 'are', 'razr', 'owner', 'you', 'must', 'have', 'this']
     );
     t.deepEqual(
+        // eslint-disable-next-line max-len
         tokenize('Tied to charger for conversations lasting more than 45 minutes.MAJOR PROBLEMS!!'),
+        // eslint-disable-next-line max-len
         ['tied', 'to', 'charger', 'for', 'conversations', 'lasting', 'more', 'than', '45', 'minutes', 'major', 'problems']
     );
     t.end();


### PR DESCRIPTION
It will be better if you will replace punctuation in tokenizer with space. Because you can have sentence like next: "If you are Razr owner...you must have this!" In previous sentence your tokenizer will return next wrong array:
`['if', 'you', 'are', 'razr', 'owneryou', 'must', 'have', 'this']`
The error in - 'owneryou'