### PR TITLE
Define "editor.tabSize" parameter to 4 for VSCode use

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 4
+}


### PR DESCRIPTION
To prevent issues with VSCode, here's a pre-defined configuration to force the use of 4 spaces indentation and tabs.