### PR TITLE
remove single quotes around words while preserving apostrophes

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -6,9 +6,19 @@
  * @return {array}        Array of tokens
  */
 module.exports = function(input) {
-    return input
+    input = input
         .toLowerCase()
         .replace(/\n/g, ' ')
         .replace(/[.,\/#!$%\^&\*;:{}=_`\"~()]/g, '')
         .split(' ');
+    // remove single quotes surrounding words but preserve apostrophes
+    var i;
+    for (i = 0; i < input.length; i++) {
+        var word = input[i];
+        if (word[0] === '\'' && word[word.length-1] === '\'') {
+            word = word.substr(1, word.length-2);
+            input[i] = word;
+        }   
+    }
+    return input;
 };

--- a/test/unit/tokenize.js
+++ b/test/unit/tokenize.js
@@ -28,6 +28,18 @@ test('english', function (t) {
         tokenize('That\'ll cause problems for the farmer\'s pigs'),
         ['that\'ll', 'cause', 'problems', 'for', 'the', 'farmer\'s', 'pigs']
     );
+    t.deepEqual(
+        tokenize('Evan is \'wrong,\', says the more qualified governor'),
+        ['evan', 'is', 'wrong', 'says', 'the','more', 'qualified', 'governor']
+    );
+    t.deepEqual(
+        tokenize('Dad told me I can be the \'honorary\' chef!'),
+        ['dad', 'told', 'me', 'i', 'can', 'be', 'the','honorary', 'chef']
+    );
+    t.deepEqual(
+        tokenize('\'Complacent\' and \'undervalued\' is a bad combination'),
+        ['complacent', 'and', 'undervalued', 'is', 'a', 'bad', 'combination']
+    );
     t.end();
 });
 


### PR DESCRIPTION
I was using the sentiment library and noticed when I ran analysis on headlines that utilized single quotes, the words were not being properly tokenized.  

For example, for the news headline from cnn.com that reads:
> Abrams: Trump is 'wrong,' I am qualified to be Georgia's governor

wrong should be tokenized from 'wrong' to wrong. 

In its current state, the library successfully tokenizes words from double quotes but not from single quotes (my guess is to preserve apostrophes - if you add an \' to the .replace regex, all single quotes would be removed).  

Here is some code to reproduce error:  

```
var Sentiment = require('sentiment');
var sentiment = new Sentiment();

let noQuotes = "Abrams: Trump is wrong, I am qualified to be Georgia's governor";
let singleQuotes = "Abrams: Trump is \'wrong\', I am qualified to be Georgia's governor";
let doubleQuotes = "Abrams: Trump is \"wrong,\" I am qualified to be Georgia's governor"

let noQuotesResult = sentiment.analyze(noQuotes);
var doubleQuotesResult = sentiment.analyze(doubleQuotes);
var singleQuotesResult = sentiment.analyze(singleQuotes);

console.log(noQuotesResult);
console.log(doubleQuotesResult);
console.log(singleQuotesResult);
```

```
{ score: -2,
  comparative: -0.18181818181818182,
  tokens:
   [ 'abrams',
     'trump',
     'is',
     'wrong',
     'i',
     'am',
     'qualified',
     'to',
     'be',
     'georgia\'s',
     'governor' ],
  words: [ 'wrong' ],
  positive: [],
  negative: [ 'wrong' ] }
{ score: -2,
  comparative: -0.18181818181818182,
  tokens:
   [ 'abrams',
     'trump',
     'is',
     'wrong',
     'i',
     'am',
     'qualified',
     'to',
     'be',
     'georgia\'s',
     'governor' ],
  words: [ 'wrong' ],
  positive: [],
  negative: [ 'wrong' ] }
{ score: 0,
  comparative: 0,
  tokens:
   [ 'abrams',
     'trump',
     'is',
     '\'wrong\'',
     'i',
     'am',
     'qualified',
     'to',
     'be',
     'georgia\'s',
     'governor' ],
  words: [],
  positive: [],
  negative: [] }
```
